### PR TITLE
[!HOTFIX] 파일 매니저에서 json 파일을 정상적으로 불러오지 못하는 버그 수정

### DIFF
--- a/IntoHistory.xcodeproj/project.pbxproj
+++ b/IntoHistory.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		260F999C289D1B460010E258 /* IntoHistory.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 260F999A289D1B460010E258 /* IntoHistory.xcdatamodeld */; };
 		260F999E289D1B470010E258 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 260F999D289D1B470010E258 /* Assets.xcassets */; };
 		260F99A1289D1B470010E258 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 260F999F289D1B470010E258 /* LaunchScreen.storyboard */; };
+		264B547228AA1C9B00726AB0 /* course_json.json in Resources */ = {isa = PBXBuildFile; fileRef = 9828EC8A28A600DF00D0D82E /* course_json.json */; };
+		264B547328AA1C9B00726AB0 /* person_json.json in Resources */ = {isa = PBXBuildFile; fileRef = 9828EC8928A600DF00D0D82E /* person_json.json */; };
 		2694641428A65FD000485526 /* HeroListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2694641328A65FD000485526 /* HeroListCell.swift */; };
 		2694641928A6973C00485526 /* HeroListDescriptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2694641828A6973C00485526 /* HeroListDescriptionCell.swift */; };
 		2694641B28A7577300485526 /* CollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2694641A28A7577300485526 /* CollectionViewHeader.swift */; };
@@ -226,6 +228,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				264B547228AA1C9B00726AB0 /* course_json.json in Resources */,
+				264B547328AA1C9B00726AB0 /* person_json.json in Resources */,
 				260F99A1289D1B470010E258 /* LaunchScreen.storyboard in Resources */,
 				260F999E289D1B470010E258 /* Assets.xcassets in Resources */,
 			);


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 파일매니저에서 json 파일을 정상적으로 불러오지 못하는 버그 발생
- pbx에서 bundle resource 부분에 json 파일들이 빠진 것으로 추정되어 해당 부분을 수정

## Key Changes 🔥 (주요 구현/변경 사항)
- 파일 매니저에서 json 파일을 정상적으로 불러오지 못하는 버그 수정

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
- 없음

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 핫픽스입니다. 간단한 수정이지만 pbx 수정인 만큼 주의해서 봐주시면 감사하겠습니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #79 
