### PR TITLE
[Feature] 영웅을 클릭했을 때 모달 띄우고, 닫기 버튼 클릭으로 모달 닫는 기능 추가

### DIFF
--- a/IntoHistory/HeroDetailViewController.swift
+++ b/IntoHistory/HeroDetailViewController.swift
@@ -56,6 +56,7 @@ class HeroDetailViewController: UIViewController {
 
         attribute()
         layout()
+        setButtonGesture()
     }
     
     // MARK: - Method
@@ -114,6 +115,16 @@ class HeroDetailViewController: UIViewController {
             paddingBottom: 60,
             paddingRight: 20
         )
+    }
+    
+    private func setButtonGesture() {
+        let tapCloseButton = UITapGestureRecognizer(target: self, action: #selector(self.tapCloseButton(_:)))
+        closeButton.addGestureRecognizer(tapCloseButton)
+        closeButton.isUserInteractionEnabled = true
+    }
+    
+    @objc func tapCloseButton(_ sender: UITapGestureRecognizer) {
+        self.dismiss(animated: false, completion: nil)
     }
 }
 

--- a/IntoHistory/HeroListViewController.swift
+++ b/IntoHistory/HeroListViewController.swift
@@ -96,11 +96,13 @@ extension HeroListViewController: UICollectionViewDataSource, UICollectionViewDe
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HeroListCell.identifier, for: indexPath) as! HeroListCell
             cell.imageView.image = UIImage(named: resistanceData.images[indexPath.row])
             cell.labelView.text = resistanceData.names[indexPath.row]
+            cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapHeroCell(_:))))
             return cell
         } else {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HeroListCell.identifier, for: indexPath) as! HeroListCell
             cell.imageView.image = UIImage(named: warriorData.images[indexPath.row])
             cell.labelView.text = warriorData.names[indexPath.row]
+            cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(tapHeroCell(_:))))
             return cell
         }
     }
@@ -158,5 +160,11 @@ extension HeroListViewController: UICollectionViewDataSource, UICollectionViewDe
             return UIEdgeInsets(top: 20, left: 0, bottom: 30, right: 0)
         }
         return UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30)
+    }
+
+    @objc func tapHeroCell(_ sender: UITapGestureRecognizer) {
+        let popupVC = HeroDetailViewController()
+        popupVC.modalPresentationStyle = .overFullScreen
+        present(popupVC, animated: false, completion: nil)
     }
 }


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 영웅 목록에서 영웅을 클릭했을 때 영웅의 상세정보를 보여주기 위해 모달을 띄우는 기능이 필요하여 추가
- 영웅 상세 모달에서 닫기 버튼을 눌렀을 때 모달을 닫는 기능이 필요하여 추가

## Key Changes 🔥 (주요 구현/변경 사항)
- 영웅 목록에서 영웅을 클릭했을 때 모달을 띄워주는 기능 추가
- 영웅 상세 모달에서 닫기 버튼을 눌렀을 때 모달을 닫는 기능 추가 b1ee5f2

## ToDo 📆 (남은 작업)
- [x] 팝업 닫기 기능 b1ee5f2
- [ ] 모달에 영웅 데이터 연동

## ScreenShot 📷 (참고 사진)
![Aug-16-2022 02-03-05](https://user-images.githubusercontent.com/81027256/184681262-c216c825-3424-477a-b8f9-1e08814ca03a.gif)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 팝업을 띄우는 기능을 구현했습니다. 꽤나 짧고 간결한 코드이니 꼼꼼한 리뷰 부탁드립니다.
- 닫기 버튼으로 팝업을 닫는 기능이 추가되었습니다. 추가 리뷰 부탁드립니다.

## Reference 🔗
- [Soda Blog - [iOS/Swift] 모서리가 둥근, 그림자가 적용된 팝업 뷰 구현하기](https://jellysong.tistory.com/82)

## Close Issues 🔒 (닫을 Issue)
- Close #95 
- Close #98 
