### PR TITLE
[!HOTFIX] 맵 뷰 메모리 누수 버그 해결 및 카메라 이동시 맵 핀 해제 기능 추가

### DIFF
--- a/IntoHistory/NMapViewController.swift
+++ b/IntoHistory/NMapViewController.swift
@@ -203,3 +203,23 @@ class NMapViewController: UIViewController, CLLocationManagerDelegate {
     }
 }
 
+extension NMapViewController: NMFMapViewCameraDelegate {
+    func mapView(_ mapView: NMFMapView, cameraIsChangingByReason reason: Int) {
+        if reason == -1 {
+            for i in 0..<booleanArray.count {
+                markers[i].mapView = nil
+                booleanArray[i] = false
+                markers[i].iconImage = NMFOverlayImage(
+                    image: UIImage(imageLiteralResourceName: SelectedTypes(rawValue: i + 1)?
+                        .selectedPinsImage(isSelecting: booleanArray[i]) ?? ""))
+                markers[i].mapView = naverMapView.mapView
+                if booleanArray[i] {
+                    hStackView.isHidden = false
+                } else {
+                    hStackView.isHidden = true
+                }
+            }
+        }
+    }
+}
+

--- a/IntoHistory/NMapViewController.swift
+++ b/IntoHistory/NMapViewController.swift
@@ -8,12 +8,16 @@ import CoreLocation
 import UIKit
 
 import NMapsMap
-	
+
+let naverMapView = NMFNaverMapView()
+
 class NMapViewController: UIViewController, CLLocationManagerDelegate {
 
     // MARK: - Property
 
     var locationManager = CLLocationManager()
+    var booleanArray = [Bool]()
+    var markers = [NMFMarker()]
 
     // MARK: - View
 
@@ -53,7 +57,8 @@ class NMapViewController: UIViewController, CLLocationManagerDelegate {
 
         attribute()
 
-        let naverMapView = NMFNaverMapView(frame: view.frame)
+        naverMapView.frame = view.frame
+        naverMapView.mapView.addCameraDelegate(delegate: self)
         naverMapView.showLocationButton = true
         naverMapView.showZoomControls = false
 
@@ -124,9 +129,6 @@ class NMapViewController: UIViewController, CLLocationManagerDelegate {
 
         titleLabel.text = coreDataManager.coursePins[0].pinName
         addressLabel.text = coreDataManager.coursePins[0].address
-
-        var booleanArray = [Bool]()
-        var markers = [NMFMarker()]
 
         for pinNum in 0..<coreDataManager.coursePins.count {
 


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 맵 뷰에 들어갔다 왔을 때, 메모리가 해제되지 않고 남아서, 그 상태로 다시 맵 뷰에 들어가게 되면 메모리가 중첩되다가 누수 현상이 일어나 앱이 뻗어버리는 현상 발생
- 맵 뷰에서 카메라를 이동시켜도 핀이 그대로 유지되는 불편함 해소

## Key Changes 🔥 (주요 구현/변경 사항)
- 맵 객체 자체를 전역으로 주어서 맵 뷰에 들어갔다 나와도 새로운 객체를 생성하지 않아 메모리에 처음 한 번만 쌓이고 더이상 쌓이지 않게하여 메모리 누수 버그 해결
- 맵 뷰에서 카메라를 이동시키면 핀이 해제되고, 또 선택되었던 핀의 정보도 가려주는 기능 추가

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
- 추후에 추가할 예정

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 꽤 오랜시간을 고민하고 생각한 것 치곤 정말 좋지 못한 솔루션으로 해결해버렸습니다.
- 현재 방법은 어디까지나 최우선으로 구현할 수 있는 방법이었을 뿐, 최선의 방법은 아니니 해당 방법을 후에 참고해서 사용하지는 않으셨으면 좋겠습니다.
- 정말 간단한 코드이지만, 버그 픽스와 관련된 부분이니 세심한 리뷰 부탁드립니다.

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
- Close #140 
- Close #141 

