### PR TITLE
[!HOTFIX] 실시간으로 위치를 파악해 중복알림이 가는 버그 수정(임시방편)

### DIFF
--- a/IntoHistory/AppDelegate.swift
+++ b/IntoHistory/AppDelegate.swift
@@ -65,13 +65,13 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        if response.notification.request.content.body == "그들이 지켜낸 대한민국\n우리들의 영웅을 기억해주세요🇰🇷" {
-            guard let rootViewController = (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.window?.rootViewController else {
-                return
-            }
-           if let navController = rootViewController as? UINavigationController{
-               navController.pushViewController(DetailCourseViewController(), animated: true)
-            }
-        }
+//        if response.notification.request.content.body == "그들이 지켜낸 대한민국\n우리들의 영웅을 기억해주세요🇰🇷" {
+//            guard let rootViewController = (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.window?.rootViewController else {
+//                return
+//            }
+//           if let navController = rootViewController as? UINavigationController{
+//               navController.pushViewController(MainViewController(), animated: true)
+//            }
+//        }
     }
 }

--- a/IntoHistory/LocationService.swift
+++ b/IntoHistory/LocationService.swift
@@ -76,10 +76,10 @@ class LocationService: NSObject {
     
     private func makeNotification() {
         setLocationManager()
-        for i in 0..<pinData.count {
-            let lat = pinData[i].lat
-            let long = pinData[i].lng
-            pinName = pinData[i].pinName
+        for num in 0..<pinData.count {
+            let lat = pinData[num].lat
+            let long = pinData[num].lng
+            pinName = pinData[num].pinName
             
             let location = CLLocationCoordinate2D(latitude: lat, longitude: long)
             let region = CLCircularRegion(center: location, radius: 50.0, identifier: "id\(location)")
@@ -97,7 +97,6 @@ class LocationService: NSObject {
                 content.title = title
                 content.body = body
                 
-//                let uuidString = UUID().uuidString
                 let identifier = identifier
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
                 let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)

--- a/IntoHistory/LocationService.swift
+++ b/IntoHistory/LocationService.swift
@@ -16,6 +16,7 @@ class LocationService: NSObject {
     var locationManager: CLLocationManager!
     var allRegions = [CLRegion]()
     let pinData = coreDataManager.pins
+    var pinName = ""
     var currentPinData: PinEntity = coreDataManager.pins[0]
     var currentLocation : CLLocation?{
         didSet{
@@ -78,6 +79,7 @@ class LocationService: NSObject {
         for i in 0..<pinData.count {
             let lat = pinData[i].lat
             let long = pinData[i].lng
+            pinName = pinData[i].pinName
             
             let location = CLLocationCoordinate2D(latitude: lat, longitude: long)
             let region = CLCircularRegion(center: location, radius: 50.0, identifier: "id\(location)")
@@ -86,7 +88,7 @@ class LocationService: NSObject {
         }
     }
     
-    private func fireNotification(_ title: String = "Background Test", body: String){
+    private func fireNotification(_ title: String = "Background Test", body: String, identifier: String){
         let notificationCenter = UNUserNotificationCenter.current()
         
         notificationCenter.getNotificationSettings{
@@ -95,9 +97,10 @@ class LocationService: NSObject {
                 content.title = title
                 content.body = body
                 
-                let uuidString = UUID().uuidString
+//                let uuidString = UUID().uuidString
+                let identifier = identifier
                 let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-                let request = UNNotificationRequest(identifier: "test-\(uuidString)", content: content, trigger: trigger)
+                let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
                 notificationCenter.add(request, withCompletionHandler: { (error) in
                     if error != nil { }
                 })
@@ -126,7 +129,7 @@ extension LocationService: CLLocationManagerDelegate {
         case .inside:
             makePinData(region: region)
             fireNotification("\(currentPinData.pinName) 방문완료❣️",
-                             body: "그들이 지켜낸 대한민국\n우리들의 영웅을 기억해주세요🇰🇷")
+                             body: "그들이 지켜낸 대한민국\n우리들의 영웅을 기억해주세요🇰🇷", identifier: pinName)
             coreDataManager.updatePinIsVisited(pin: currentPinData)
         case .outside:
             print("나감")


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 실시간 위치를 파악해 위치가 변경시 계속 동일한 알림이가서
일단은.. 핀이름을 identifier로 줘서 한 알림에 중복으로 뜨게 임시방편으로 처리함,,

## Key Changes 🔥 (주요 구현/변경 사항)
일단은 로직이 생각이안나서 브라운의 도움으로 해결한거라..
추후 수정이 필요함.. 동일 알림이 같은 알림에서 바뀌는거라.. 
다른 지역가도 알림이 새로 안 만들어짐
## ToDo 📆 (남은 작업)
- [ ] todo

## ScreenShot 📷 (참고 사진)

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

## Reference 🔗

## Close Issues 🔒 (닫을 Issue)
Close #143
