### PR TITLE
[Chore] 상세 코스 최하단 버튼 멘트 수정

### DIFF
--- a/IntoHistory/DetailCourseView/DetailCourseViewController.swift
+++ b/IntoHistory/DetailCourseView/DetailCourseViewController.swift
@@ -139,7 +139,7 @@ extension DetailCourseViewController:  UICollectionViewDelegate, UICollectionVie
             } else {
                 footer.arButtonShape.backgroundColor = .inactiveButtonColor
                 footer.arButtonLabel.textColor = .popupDim
-                footer.arButtonLabel.text = "코스의 핀들을 모두 방문해야 활성화 돼요"
+                footer.arButtonLabel.text = "코스의 핀들을 모두 방문해보세요~"
             }
 
             return footer


### PR DESCRIPTION
## Motivation 🥳 (코드를 추가/변경하게 된 이유)
- 상세 코스 하단의 버튼이 비활성화 상태일 때는 버튼으로 보이지 않는데 버튼 활성화라는 워딩이 직접 들어가서 어울리지 않아보임
- 조금 더 권유의 표현으로 변경이 필요했음

## Key Changes 🔥 (주요 구현/변경 사항)
- 상세 코스 하단의 버튼 멘트 권유의 표현으로 수정

## ToDo 📆 (남은 작업)
- 없음

## ScreenShot 📷 (참고 사진)
<img src="https://user-images.githubusercontent.com/81027256/186423223-40a273d9-6869-438d-b09a-a7e944458956.png" width="300">

## To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 간단한 멘트 수정이며, 추가 작업입니다. 가볍게 리뷰해주셔도 좋습니다~

## Reference 🔗
- 없음

## Close Issues 🔒 (닫을 Issue)
Close #168 
